### PR TITLE
Issue4-design_ProGAN_architecture

### DIFF
--- a/code/train.py
+++ b/code/train.py
@@ -282,9 +282,9 @@ class WGAN_GP(torch.nn.Module):
 
 #-------------------------------------------------------------------------------------------------------------------------------------------
 # TODO: JEONGWON IMPLEMENT THIS SECTION - MODEL ARCHITECTURE
-"""ProGAN Generator - progressively grows from 4x4 to target resolution.
+"""
+    ProGAN Generator - progressively grows from 4x4 to target resolution.
     Based on: https://arxiv.org/abs/1710.10196
-    
     NOTE: AI ASSISTED WITH THIS ARCHITECTURE
 """
 class Generator_ProGAN(nn.Module):

--- a/code/train.py
+++ b/code/train.py
@@ -437,7 +437,6 @@ class Discriminator_ProGAN(nn.Module):
 
         return self.final(out)
 
-
 class ProGAN(torch.nn.Module):
     def __init__(self, latent_dim=LATENT_DIM, channels=CHANNELS, feature_maps=512):
         super(ProGAN, self).__init__()


### PR DESCRIPTION
Implemented ProGAN architecture (Generator, Discriminator, ProGAN wrapper)
- Progressive growing from 4x4 to 128x128 with fade-in (alpha blending)
- Added tune_progan and train_progan functions
- Uses WGAN-GP style loss with gradient penalty
- Added step/alpha support to generate_images for ProGAN evaluation
- ProGAN uses progressive generation, needs step and alpha unlike DCGAN/WGAN-GP
- Updated ProGAN test section to load checkpoint and generate at final resolution
- Backward compatible: DCGAN/WGAN-GP unchanged